### PR TITLE
fix broken URL to botium documentation;

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <img src="robotmate.jpg" alt="Robot Mate" width="600"/>
 
-This project is based on [Botium](https://botium.atlassian.net) and is used for testing the communication path with a chatbot using **dialogflow**. Here you will find how to setup and run the project, plus conversations simulating a real user in order to test the platform answers to guarantee a better coverage of the bot.
+This project is based on [Botium](https://botium.atlassian.net/wiki/spaces/BOTIUM/overview) and is used for testing the communication path with a chatbot using **dialogflow**. Here you will find how to setup and run the project, plus conversations simulating a real user in order to test the platform answers to guarantee a better coverage of the bot.
 
 ## Installation
 


### PR DESCRIPTION
the originally used URL just ends up on the atlassian login page;